### PR TITLE
(Bug) Use Unicode kernel32 functions.

### DIFF
--- a/Stugo.Interop/Windows/WindowsUnmanagedModuleLoader.cs
+++ b/Stugo.Interop/Windows/WindowsUnmanagedModuleLoader.cs
@@ -9,10 +9,10 @@ namespace Stugo.Interop.Windows
 {
     public class WindowsUnmanagedModuleLoader : UnmanagedModuleLoaderBase
     {
-        [DllImport("kernel32.dll")]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         protected static extern IntPtr LoadLibrary(string filename);
 
-        [DllImport("kernel32.dll")]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         protected static extern IntPtr GetProcAddress(IntPtr hModule, string procname);
 
 


### PR DESCRIPTION
"LoadLibrary" was actually causing a crash.

"GerProcAddress" for good measure.